### PR TITLE
Fix up test code

### DIFF
--- a/tutorial-contents/401_CNN.py
+++ b/tutorial-contents/401_CNN.py
@@ -122,7 +122,7 @@ for epoch in range(EPOCH):
 plt.ioff()
 
 # print 10 predictions from test data
-test_output = cnn(test_x[:10])
+test_output, _ = cnn(test_x[:10])
 pred_y = torch.max(test_output, 1)[1].data.numpy().squeeze()
 print(pred_y, 'prediction number')
 print(test_y[:10].numpy(), 'real number')


### PR DESCRIPTION
As the forward code is defined returning x for visualization as well, we seem to need to update the test code accordingly otherwise error will prop up.
```
def forward(self, x):
    x = self.conv1(x)
    x = self.conv2(x)
    x = x.view(x.size(0), -1)           # flatten the output of conv2 to (batch_size, 32 * 7 * 7)
    output = self.out(x)
    return output, x    # return x for visualization
```