### PR TITLE
Remove deprecated code

### DIFF
--- a/tutorial-contents/301_regression.py
+++ b/tutorial-contents/301_regression.py
@@ -17,8 +17,8 @@ x = torch.unsqueeze(torch.linspace(-1, 1, 100), dim=1)  # x data (tensor), shape
 y = x.pow(2) + 0.2*torch.rand(x.size())                 # noisy y data (tensor), shape=(100, 1)
 
 # torch can only train on Variable, so convert them to Variable
-x, y = Variable(x), Variable(y)
-
+#x, y = Variable(x), Variable(y)
+#The above code is depricated. Now,autograd directly supports tensors
 # plt.scatter(x.data.numpy(), y.data.numpy())
 # plt.show()
 


### PR DESCRIPTION
The use of Variable() explicitly is deprecated as Autograd now supports tensors directly.