### PR TITLE
Fixing error learning rate for this sample

### DIFF
--- a/tutorial-contents-notebooks/301_regression.ipynb
+++ b/tutorial-contents-notebooks/301_regression.ipynb
@@ -125,7 +125,7 @@
    },
    "outputs": [],
    "source": [
-    "optimizer = torch.optim.SGD(net.parameters(), lr=0.5)\n",
+    "optimizer = torch.optim.SGD(net.parameters(), lr=0.4)\n",
     "loss_func = torch.nn.MSELoss()  # this is for regression mean squared loss"
    ]
   },
@@ -261,7 +261,7 @@
     "        plt.cla()\n",
     "        plt.scatter(x.data.numpy(), y.data.numpy())\n",
     "        plt.plot(x.data.numpy(), prediction.data.numpy(), 'r-', lw=5)\n",
-    "        plt.text(0.5, 0, 'Loss=%.4f' % loss.data[0], fontdict={'size': 20, 'color':  'red'})\n",
+    "        plt.text(0.5, 0, 'Loss=%.4f' % loss.item(), fontdict={'size': 20, 'color':  'red'})\n",
     "        plt.show()\n",
     "        plt.pause(0.2)\n",
     "\n",


### PR DESCRIPTION
@MorvanZhou 
Thanks for giving this kind tutorial for everyone who is learning pytorch.
By the way, there are one syntax warning should be fixed in your code for the future version pytorch (>0.5).

> Use tensor.item() to convert a 0-dim tensor to a Python number

Another one problem is about the learning rate for this example, lr = 0.5 was too big that will not changing loss in this example, so I revise it as 0.4.