### PR TITLE
[Bug fix] 201-torch-numpy tensor.dot

### DIFF
--- a/tutorial-contents-notebooks/201_torch_numpy.ipynb
+++ b/tutorial-contents-notebooks/201_torch_numpy.ipynb
@@ -19,9 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
@@ -37,7 +35,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\nnumpy array: [[0 1 2]\n [3 4 5]] \ntorch tensor: tensor([[ 0,  1,  2],\n        [ 3,  4,  5]], dtype=torch.int32) \ntensor to array: [[0 1 2]\n [3 4 5]]\n"
+      "\n",
+      "numpy array: [[0 1 2]\n",
+      " [3 4 5]] \n",
+      "torch tensor: tensor([[0, 1, 2],\n",
+      "        [3, 4, 5]]) \n",
+      "tensor to array: [[0 1 2]\n",
+      " [3 4 5]]\n"
      ]
     }
    ],
@@ -62,7 +66,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\nabs \nnumpy:  [1 2 1 2] \ntorch:  tensor([ 1.,  2.,  1.,  2.])\n"
+      "\n",
+      "abs \n",
+      "numpy:  [1 2 1 2] \n",
+      "torch:  tensor([1., 2., 1., 2.])\n"
      ]
     }
    ],
@@ -85,7 +92,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([ 1.,  2.,  1.,  2.])"
+       "tensor([1., 2., 1., 2.])"
       ]
      },
      "execution_count": 4,
@@ -106,7 +113,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\nsin \nnumpy:  [-0.84147098 -0.90929743  0.84147098  0.90929743] \ntorch:  tensor([-0.8415, -0.9093,  0.8415,  0.9093])\n"
+      "\n",
+      "sin \n",
+      "numpy:  [-0.84147098 -0.90929743  0.84147098  0.90929743] \n",
+      "torch:  tensor([-0.8415, -0.9093,  0.8415,  0.9093])\n"
      ]
     }
    ],
@@ -127,7 +137,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([ 0.2689,  0.1192,  0.7311,  0.8808])"
+       "tensor([0.2689, 0.1192, 0.7311, 0.8808])"
       ]
      },
      "execution_count": 6,
@@ -147,7 +157,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([ 0.3679,  0.1353,  2.7183,  7.3891])"
+       "tensor([0.3679, 0.1353, 2.7183, 7.3891])"
       ]
      },
      "execution_count": 7,
@@ -168,7 +178,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\nmean \nnumpy:  0.0 \ntorch:  tensor(0.)\n"
+      "\n",
+      "mean \n",
+      "numpy:  0.0 \n",
+      "torch:  tensor(0.)\n"
      ]
     }
    ],
@@ -190,7 +203,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\nmatrix multiplication (matmul) \nnumpy:  [[ 7 10]\n [15 22]] \ntorch:  tensor([[  7.,  10.],\n        [ 15.,  22.]])\n"
+      "\n",
+      "matrix multiplication (matmul) \n",
+      "numpy:  [[ 7 10]\n",
+      " [15 22]] \n",
+      "torch:  tensor([[ 7., 10.],\n",
+      "        [15., 22.]])\n"
      ]
     }
    ],
@@ -208,29 +226,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "matrix multiplication (dot) \n",
-      "numpy:  [[ 7 10]\n",
-      " [15 22]] \n",
-      "torch:  30.0\n"
+     "ename": "RuntimeError",
+     "evalue": "dot: Expected 1-D argument self, but got 2-D",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0mTraceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-10-c325661bdee8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;34m'\\nmatrix multiplication (dot)'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0;34m'\\nnumpy: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m        \u001b[0;31m# [[7, 10], [15, 22]]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 7\u001b[0;31m     \u001b[0;34m'\\ntorch: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtensor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtensor\u001b[0m\u001b[0;34m)\u001b[0m     \u001b[0;31m# 30.0. Beware that torch.dot does not broadcast, only works for 1-dimensional tensor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      8\u001b[0m )\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: dot: Expected 1-D argument self, but got 2-D"
      ]
     }
    ],
    "source": [
     "# incorrect method\n",
     "data = np.array(data)\n",
-    "tensor = torch.Tensor([1,2,3,4]\n",
+    "tensor = torch.Tensor(data)\n",
     "print(\n",
     "    '\\nmatrix multiplication (dot)',\n",
     "    '\\nnumpy: ', data.dot(data),        # [[7, 10], [15, 22]]\n",
-    "    '\\ntorch: ', torch.dot(tensor.dot(tensor)     # 30.0. Beware that torch.dot does not broadcast, only works for 1-dimensional tensor\n",
+    "    '\\ntorch: ', tensor.dot(tensor)     # 30.0. Beware that torch.dot does not broadcast, only works for 1-dimensional tensor\n",
     ")"
    ]
   },
@@ -247,16 +265,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[  7.,  10.],\n        [ 15.,  22.]])"
+       "tensor([[ 7., 10.],\n",
+       "        [15., 22.]])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,16 +286,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[  1.,   4.],\n        [  9.,  16.]])"
+       "tensor([[ 1.,  4.],\n",
+       "        [ 9., 16.]])"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,9 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -331,7 +349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the cell
```
# incorrect method
data = np.array(data)
tensor = torch.Tensor([1,2,3,4]
print(
    '\nmatrix multiplication (dot)',
    '\nnumpy: ', data.dot(data),        # [[7, 10], [15, 22]]
    '\ntorch: ', torch.dot(tensor.dot(tensor)     # 30.0. Beware that torch.dot does not broadcast, only works for 1-dimensional tensor
)
```
it want to show tensor.dot() don't work with 2-D input, but it pass 1-D tensor.