### PR TITLE
302 - remove .squeeze() from 1-D numpy array

### DIFF
--- a/tutorial-contents/302_classification.py
+++ b/tutorial-contents/302_classification.py
@@ -59,7 +59,7 @@ for t in range(100):
         # plot and show learning process
         plt.cla()
         prediction = torch.max(out, 1)[1]
-        pred_y = prediction.data.numpy().squeeze()
+        pred_y = prediction.data.numpy()
         target_y = y.data.numpy()
         plt.scatter(x.data.numpy()[:, 0], x.data.numpy()[:, 1], c=pred_y, s=100, lw=0, cmap='RdYlGn')
         accuracy = float((pred_y == target_y).astype(int).sum()) / float(target_y.size)


### PR DESCRIPTION
`prediction.data.numpy()` is already 1-D, so the `.squeeze()` is unnecessary.