### PR TITLE
403_RNN_regressor.py missing line in comment

### DIFF
--- a/tutorial-contents/403_RNN_regressor.py
+++ b/tutorial-contents/403_RNN_regressor.py
@@ -57,6 +57,11 @@ class RNN(nn.Module):
         # outs = self.out(r_out)
         # outs = outs.view(-1, TIME_STEP, 1)
         # return outs, h_state
+        
+        # or even simpler, since nn.Linear can accept inputs of any dimension 
+        # and returns outputs with same dimension except for the last
+        # outs = self.out(r_out)
+        # return outs
 
 rnn = RNN()
 print(rnn)

--- a/tutorial-contents/403_RNN_regressor.py
+++ b/tutorial-contents/403_RNN_regressor.py
@@ -55,6 +55,7 @@ class RNN(nn.Module):
         # instead, for simplicity, you can replace above codes by follows
         # r_out = r_out.view(-1, 32)
         # outs = self.out(r_out)
+        # outs = outs.view(-1, TIME_STEP, 1)
         # return outs, h_state
 
 rnn = RNN()


### PR DESCRIPTION
Reference to https://morvanzhou.github.io/tutorials/machine-learning/torch/4-03-RNN-regression/, I found `outs = outs.view(-1, TIME_STEP, 1)`  is actually missing here. And this also solves https://github.com/MorvanZhou/PyTorch-Tutorial/issues/46.