### PR TITLE
循环的最后一个元素和下一次循环的第一个元素时间不连续

### DIFF
--- a/tutorial-contents/403_RNN_regressor.py
+++ b/tutorial-contents/403_RNN_regressor.py
@@ -77,7 +77,7 @@ plt.ion()           # continuously plot
 for step in range(100):
     start, end = step * np.pi, (step+1)*np.pi   # time range
     # use sin predicts cos
-    steps = np.linspace(start, end, TIME_STEP, dtype=np.float32)  # float32 for converting torch FloatTensor
+    steps = np.linspace(start, end, TIME_STEP, dtype=np.float32, endpoint=False)  # float32 for converting torch FloatTensor
     x_np = np.sin(steps)
     y_np = np.cos(steps)
 


### PR DESCRIPTION
steps = np.linspace(start, end, TIME_STEP, dtype=np.float32)
其中默认参数endpoint=True，也就是说这一次循环的最后一个元素和下一次循环的第一个元素是一致的，按照RNN传递的state的特点，应该保证输入是关于时间连续的，所以不应该有相邻的时间是一致的情况，这可能不是想要的，所以我认为这里是一个小bug。